### PR TITLE
Fix JSONDecodeError in extract_finance_news and update deprecated Action

### DIFF
--- a/.github/workflows/python-cron.yml
+++ b/.github/workflows/python-cron.yml
@@ -22,21 +22,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
         id: setup_python
       # Poetry cache depends on OS, Python version and Poetry version.
       - name: Cache Poetry cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pypoetry
           key: poetry-cache-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ env.POETRY_VERSION }}
       # virtualenv cache should depends on OS, Python version and `poetry.lock` (and optionally workflow files).
       - name: Cache Packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.local
           key: poetry-local-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('.github/workflows/*.yml') }}

--- a/crawling.py
+++ b/crawling.py
@@ -73,7 +73,13 @@ def extract_finance_news(soup):
     upload_contents = '## Finance News\n\n'
     # 리스트 아이템들을 모두 선택 (상대경로, 태그 위주)
     
-    json_text = soup.get_text()
+    pre_tag = soup.find('pre')
+    json_text = pre_tag.get_text() if pre_tag else soup.get_text()
+    json_text = json_text.strip()
+
+    if not json_text:
+        return upload_contents
+
     json_data = json.loads(json_text)
 
     summary = json_data.get('data', {}).get('summary', '')


### PR DESCRIPTION
- Extract JSON from pre tag first (browser wraps JSON API responses in pre)
- Add guard for empty json_text to avoid JSONDecodeError
- Upgrade actions/checkout v3→v4, setup-python v4→v5, cache v3→v4 (Node.js 20 EOL June 16, 2026)